### PR TITLE
erase the security register pages before writing

### DIFF
--- a/spi.c
+++ b/spi.c
@@ -347,6 +347,22 @@ void spiWriteSecurity(struct ff_spi *spi, uint8_t sr, uint8_t security[256]) {
 	spiCommand(spi, 0x06);
 	spiEnd(spi);
 
+	// erase the register
+	spiBegin(spi);
+	spiCommand(spi, 0x44);
+	spiCommand(spi, 0x00); // A23-16
+	spiCommand(spi, sr);   // A15-8
+	spiCommand(spi, 0x00); // A0-7
+	spiEnd(spi);
+
+	spi_get_id(spi);
+	sleep(1);
+
+	// write enable
+	spiBegin(spi);
+	spiCommand(spi, 0x06);
+	spiEnd(spi);
+
 	spiBegin(spi);
 	spiCommand(spi, 0x42);
 	spiCommand(spi, 0x00); // A23-16


### PR DESCRIPTION
The write security register command doesn't reset the page to 0xFF, so a second write will be corrupted. This patch adds an erase command, sleeps for a second (should poll status register?), and then sends the data.