### PR TITLE
added option (-u) to unlock SPI roms 

### DIFF
--- a/fomu-flash.c
+++ b/fomu-flash.c
@@ -161,6 +161,7 @@ static int print_help(FILE *stream, const char *progname) {
     fprintf(stream, "    -g ps     Set the pin assignment with the given pinspec\n");
 #ifndef DEBUG_ICE40_PATCH
     fprintf(stream, "    -t type   Set the number of bits to use for SPI (1, 2, 4, or Q)\n");
+    fprintf(stream, "    -u        Unlock the SPI Global Block Protect with a 0x98 command\n");
     fprintf(stream, "    -b bytes  Override the size of the SPI flash, in bytes\n");
 #endif
     fprintf(stream, "You can remap various pins with -g.  The format is [name]:[number].\n");

--- a/fomu-flash.c
+++ b/fomu-flash.c
@@ -152,7 +152,7 @@ static int print_help(FILE *stream, const char *progname) {
     fprintf(stream, "Usage:\n");
     fprintf(stream, "%15s  (-[hri] | [-p offset] | [-f bitstream] | \n", progname);
     fprintf(stream, "%15s            [-w bin] | [-v bin] | [-s out] | [-k n[:f]])\n", "");
-    fprintf(stream, "                [-g pinspec] [-t spitype] [-b bytes] [-a addr]\n");
+    fprintf(stream, "                [-g pinspec] [-t spitype] [-b bytes] [-a addr] [-u]\n");
     fprintf(stream, "\n");
     fprintf(stream, "Program mode (pick one):\n");
     print_program_modes(stream);
@@ -227,11 +227,14 @@ int main(int argc, char **argv) {
     spiSetPin(spi, SP_WP, S_WP);
     spiSetPin(spi, SP_CS, S_CE0);
 
+    // by default do not unlock the chip
+    spiSetUnlockCmd(spi, NO_UNLOCK_CMD);
+
     fpgaSetPin(fpga, FP_RESET, F_RESET);
     fpgaSetPin(fpga, FP_DONE, F_DONE);
     fpgaSetPin(fpga, FP_CS, S_CE0);
 
-    while ((opt = getopt(argc, argv, "hiqp:rf:a:b:w:s:2:3:v:g:t:k:l:4")) != -1) {
+    while ((opt = getopt(argc, argv, "hiqp:rf:a:b:w:s:2:3:v:g:t:k:l:4:u")) != -1) {
         switch (opt) {
 
         case 'a':
@@ -252,7 +255,10 @@ int main(int argc, char **argv) {
         case 'b':
             spi_flash_bytes = strtoul(optarg, NULL, 0);
             break;
-
+        
+        case 'u':
+            spiSetUnlockCmd(spi, UNLOCK_CMD);
+            break;
         case 't':
             switch (*optarg) {
             case '1':

--- a/spi.h
+++ b/spi.h
@@ -3,6 +3,9 @@
 
 #include <stdint.h>
 
+#define NO_UNLOCK_CMD 0x00
+#define UNLOCK_CMD 0x98
+
 enum spi_state {
 	SS_UNCONFIGURED = 0,
 	SS_SINGLE,
@@ -84,6 +87,7 @@ void spiSwapTxRx(struct ff_spi *spi);
 
 struct ff_spi *spiAlloc(void);
 void spiSetPin(struct ff_spi *spi, enum spi_pin pin, int val);
+void spiSetUnlockCmd(struct  ff_spi *spi, int cmd);
 void spiFree(struct ff_spi **spi);
 
 int spiSetQe(struct ff_spi *spi);


### PR DESCRIPTION
I've added very basic support to unlock spi roms that require it by specifying a -u commandline option. 

This option issues command 0x98 before any write. Other spi chips may need other commands so this could be extended in the future. 

By default no new commands are issued when running fomu-flash